### PR TITLE
fix: disable loguru logging by default to prevent debug messages in plugin context

### DIFF
--- a/src/snkmt/__init__.py
+++ b/src/snkmt/__init__.py
@@ -1,0 +1,7 @@
+from loguru import logger
+
+# Disable loguru logging by default for the snkmt namespace.
+# This prevents debug messages from leaking to stderr when snkmt is imported
+# as a library (e.g., by the snakemake logger plugin) rather than run via the CLI.
+# The CLI's verbose_callback re-enables logging when snkmt is used directly.
+logger.disable("snkmt")

--- a/src/snkmt/cli.py
+++ b/src/snkmt/cli.py
@@ -18,6 +18,7 @@ def verbose_callback(value: bool):
         lambda msg: sys.stderr.write(msg),  # type: ignore
         level="DEBUG" if value else "INFO",
     )
+    logger.enable("snkmt")
     return value
 
 


### PR DESCRIPTION
loguru's default handler (stderr, DEBUG level) was never removed when snkmt was imported as a library by the snakemake logger plugin, causing all logger.debug() calls in session.py to emit to the user's terminal during snakemake runs with --logger snkmt.

Disable logging for the snkmt namespace at package init using logger.disable(), and re-enable it in the CLI's verbose_callback so direct CLI usage is unaffected.