### PR TITLE
feat: two-screen layout redesign with log viewer, resources panel, and bug fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ textual-dev = ">=1.7.0"
 
 [tool.pixi.feature.dev.pypi-dependencies]
 snkmt = { path = ".", editable = true }
-snakemake-logger-plugin-snkmt = { git = "https://github.com/alefisico/snakemake-logger-plugin-snkmt.git", editable = true }
+snakemake-logger-plugin-snkmt = { git = "https://github.com/cademirch/snakemake-logger-plugin-snkmt.git", editable = true, branch="dev" }
 
 [tool.pixi.feature.dev.dependencies]
 pytest = ">=8.3.5,<9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ textual-dev = ">=1.7.0"
 
 [tool.pixi.feature.dev.pypi-dependencies]
 snkmt = { path = ".", editable = true }
-snakemake-logger-plugin-snkmt = { git = "https://github.com/cademirch/snakemake-logger-plugin-snkmt.git", editable = true, branch="dev" }
+snakemake-logger-plugin-snkmt = { git = "https://github.com/alefisico/snakemake-logger-plugin-snkmt.git", editable = true }
 
 [tool.pixi.feature.dev.dependencies]
 pytest = ">=8.3.5,<9"

--- a/src/snkmt/console/app.py
+++ b/src/snkmt/console/app.py
@@ -16,7 +16,7 @@ from textual import on
 from snkmt.version import VERSION
 from snkmt.console.command import SelectDatabaseCommand, DatabaseSourceProvider
 from snkmt.console.views.overview import WorkflowListView
-from snkmt.console.widgets import LogFileModal, WorkflowTable
+from snkmt.console.widgets import LogFileModal
 from snkmt.core.db.session import AsyncDatabase
 
 
@@ -69,7 +69,7 @@ class DashboardScreen(Screen):
 
     def action_force_refresh(self) -> None:
         try:
-            self.query_one(WorkflowListView).query_one(WorkflowTable)._refresh_table()
+            self.query_one(WorkflowListView).force_refresh()
         except NoMatches:
             pass
 
@@ -115,8 +115,8 @@ class DashboardScreen(Screen):
             db = AsyncDatabase(self.datasource, create_db=False)
             repo = db.get_workflow_repository()
             self.app.push_screen(WorkflowDetailScreen(repo, message.workflow_id, self.datasource))
-        except Exception:
-            pass
+        except Exception as e:
+            self.app.notify(f"Could not open workflow: {e}", severity="error")
 
 
 class snkmtApp(App):

--- a/src/snkmt/console/app.py
+++ b/src/snkmt/console/app.py
@@ -11,11 +11,12 @@ from typing import Optional
 from textual.screen import Screen
 from textual.containers import Horizontal, Container
 from textual.css.query import NoMatches
+from textual import on
 
 from snkmt.version import VERSION
 from snkmt.console.command import SelectDatabaseCommand, DatabaseSourceProvider
-from snkmt.console.views.overview import OverviewContainer
-from snkmt.console.widgets import LogFileModal
+from snkmt.console.views.overview import WorkflowListView
+from snkmt.console.widgets import LogFileModal, WorkflowTable
 from snkmt.core.db.session import AsyncDatabase
 
 
@@ -62,8 +63,17 @@ class DashboardScreen(Screen):
         ("r", "force_refresh", "Refresh"),
     ]
 
+    def __init__(self, datasource_url: Optional[str] = None) -> None:
+        super().__init__()
+        self.datasource = datasource_url
+
+    def action_force_refresh(self) -> None:
+        try:
+            self.query_one(WorkflowListView).query_one(WorkflowTable)._refresh_table()
+        except NoMatches:
+            pass
+
     def action_select_database_source(self) -> None:
-        """Open database source selector directly."""
         self.app.push_screen(
             CommandPalette(
                 providers=[DatabaseSourceProvider],
@@ -71,53 +81,42 @@ class DashboardScreen(Screen):
             )
         )
 
-    def __init__(self, datasource_url: Optional[str] = None) -> None:
-        super().__init__()
-        self.datasource = datasource_url
-        self.log.info(f"{datasource_url=}")
-
-    def action_force_refresh(self) -> None:
-        """Force refresh all visible tables."""
-        try:
-            overview = self.query_one(OverviewContainer)
-            overview.force_refresh()
-        except NoMatches:
-            pass
-
     def compose(self) -> ComposeResult:
         try:
             db = AsyncDatabase(self.datasource, create_db=False)
             repo = db.get_workflow_repository()
             yield AppHeader(datasource=db.db_path, id="header")
-            yield OverviewContainer(repo)
+            yield WorkflowListView(repo)
         except Exception as e:
             from snkmt.core.db.session import DatabaseNotFoundError
-
             error_container = Container(classes="section", id="error-container")
             error_container.border_title = "Database Connection Error"
-
             with error_container:
                 if isinstance(e, DatabaseNotFoundError):
                     error_type = "Database Not Found"
                     error_details = str(e)
-                    suggestion = (
-                        "\n Try selecting a different database source with Ctrl+P"
-                    )
+                    suggestion = "\n Try selecting a different database source with Ctrl+P"
                 else:
                     error_type = f"{type(e).__name__}"
                     error_details = str(e)
                     suggestion = "\n Check the database path and permissions"
-
                 yield Label(
-                    f"{error_type}\n\n"
-                    f"Datasource: {self.datasource}\n\n"
-                    f"Details:\n{error_details}"
-                    f"{suggestion}",
+                    f"{error_type}\n\nDatasource: {self.datasource}\n\n"
+                    f"Details:\n{error_details}{suggestion}",
                     id="error-message",
                     classes="error-text",
                 )
-
         yield Footer(id="footer")
+
+    @on(WorkflowListView.WorkflowSelected)
+    def handle_workflow_selected(self, message: WorkflowListView.WorkflowSelected) -> None:
+        from snkmt.console.views.detail import WorkflowDetailScreen
+        try:
+            db = AsyncDatabase(self.datasource, create_db=False)
+            repo = db.get_workflow_repository()
+            self.app.push_screen(WorkflowDetailScreen(repo, message.workflow_id, self.datasource))
+        except Exception:
+            pass
 
 
 class snkmtApp(App):

--- a/src/snkmt/console/app.py
+++ b/src/snkmt/console/app.py
@@ -85,13 +85,16 @@ class DashboardScreen(Screen):
             yield WorkflowListView(repo)
         except Exception as e:
             from snkmt.core.db.session import DatabaseNotFoundError
+
             error_container = Container(classes="section", id="error-container")
             error_container.border_title = "Database Connection Error"
             with error_container:
                 if isinstance(e, DatabaseNotFoundError):
                     error_type = "Database Not Found"
                     error_details = str(e)
-                    suggestion = "\n Try selecting a different database source with Ctrl+P"
+                    suggestion = (
+                        "\n Try selecting a different database source with Ctrl+P"
+                    )
                 else:
                     error_type = f"{type(e).__name__}"
                     error_details = str(e)
@@ -105,12 +108,17 @@ class DashboardScreen(Screen):
         yield Footer(id="footer")
 
     @on(WorkflowListView.WorkflowSelected)
-    def handle_workflow_selected(self, message: WorkflowListView.WorkflowSelected) -> None:
+    def handle_workflow_selected(
+        self, message: WorkflowListView.WorkflowSelected
+    ) -> None:
         from snkmt.console.views.detail import WorkflowDetailScreen
+
         try:
             db = AsyncDatabase(self.datasource, create_db=False)
             repo = db.get_workflow_repository()
-            self.app.push_screen(WorkflowDetailScreen(repo, message.workflow_id, self.datasource))
+            self.app.push_screen(
+                WorkflowDetailScreen(repo, message.workflow_id, self.datasource)
+            )
         except Exception as e:
             self.app.notify(f"Could not open workflow: {e}", severity="error")
 

--- a/src/snkmt/console/app.py
+++ b/src/snkmt/console/app.py
@@ -51,10 +51,6 @@ class AppHeader(Horizontal):
             yield Label(f"Connected to: {self.datasource}", id="app-db-path")
 
 
-class AppBody(Horizontal):
-    """The body of the app"""
-
-
 class DashboardScreen(Screen):
     COMMANDS = {SelectDatabaseCommand}
     BINDINGS = [
@@ -166,7 +162,7 @@ class snkmtApp(App):
         self.screen.focus_previous()
 
 
-def run_app(refresh_interval: float, databases: Optional[list[str]] = None):
+def run_app(refresh_interval: float, databases: Optional[list[str]] = None) -> None:
     """Run the Textual app."""
     app = snkmtApp(refresh_interval, databases)
     app.run()

--- a/src/snkmt/console/snkmt.tcss
+++ b/src/snkmt/console/snkmt.tcss
@@ -1,34 +1,22 @@
 /* ============================================================================
    SNKMT Console CSS - Textual UI Stylesheet
-   
-   Structure Overview:
-   - App Header: Title bar with app name and database path
-   - App Body: Main content area with workflow dashboard
-   - WorkflowDashboard: Horizontal layout with workflows list and detail view
-   - OverviewContainer: Current main view with filters, table, and detail panel
-   
-   Layout Hierarchy:
+
+   Structure:
    App
    ├── AppHeader
-   │   ├── #app-title
-   │   └── #app-db-path  
-   ├── AppBody
-   │   └── OverviewContainer (Horizontal)
-   │       ├── #workflows (.section)
-   │       │   ├── #workflows-filters (.subsection)
-   │       │   │   ├── #filter-layout (Horizontal grid)
-   │       │   │   │   ├── #name-filter
-   │       │   │   │   ├── #date-filter  
-   │       │   │   │   └── #status-filter
-   │       │   │   └── #workflow-counts
-   │       │   └── WorkflowTable
-   │       └── #selected-workflow-detail (.section)
-   │           └── WorkflowDetailOverview (.subsection)
-   └── Footer
-   
-   Modals:
-   - LogFileModal: For displaying log files
-   - CustomSourceModal: For database source input
+   ├── DashboardScreen
+   │   └── WorkflowListView (.section)
+   │       ├── #workflows-filters (.subsection)
+   │       │   ├── #filter-layout
+   │       │   └── #workflow-counts
+   │       └── WorkflowTable
+   └── WorkflowDetailScreen
+       ├── #detail-body (Horizontal)
+       │   ├── #detail-left (Vertical)
+       │   │   ├── #detail-rules (.subsection)
+       │   │   └── #detail-jobs (.subsection)
+       │   └── #detail-tabs (TabbedContent)
+       └── Footer
    ============================================================================ */
 
 /* ============================================================================
@@ -38,88 +26,70 @@ AppHeader {
     color: $text-primary;
     padding: 1 3;
     height: auto;
-    
+
     & > #app-db-path {
         dock: right;
         color: $text-muted;
     }
-    
-    & > #app-header-summary {
-        width: 1fr;
-        content-align: center middle;
-    }
 }
 
 /* ============================================================================
-   APP BODY & MAIN LAYOUT
+   DASHBOARD SCREEN - full-width workflow list
    ============================================================================ */
-AppBody {
+WorkflowListView {
+    height: 1fr;
     padding: 0 2;
 }
 
-OverviewContainer {
-    layout: horizontal;
+WorkflowTable {
     height: 1fr;
 }
 
-/* ============================================================================
-   WORKFLOWS SECTION (Left Panel)
-   ============================================================================ */
-#workflows {
-    width: 1fr;
-    max-width: 80;
-    padding: 0 1;
-}
-
-#workflows > * {
-    width: 100%;
-    max-width: 80;
-    align: left top;
-}
-
-/* Workflow Filters */
 #workflows-filters {
     height: auto;
     layout: vertical;
-    align: center middle;
 }
 
 #filter-layout {
     height: auto;
     layout: grid;
     grid-size: 3;
-    grid-columns: 2fr 1fr 1fr;  /* Name filter wider than date/status */
+    grid-columns: 2fr 1fr 1fr;
     grid-gutter: 1;
 }
 
-#status-filter {
-    width: 1fr;
-    max-height: 8;
-}
-
-/* Workflow Counts Label */
 #workflow-counts {
     width: 100%;
     content-align: center middle;
     color: $text-muted;
-    dock: bottom;
-}
-
-/* Workflow Table */
-WorkflowTable {
-    height: 8fr;
 }
 
 /* ============================================================================
-   WORKFLOW DETAIL SECTION (Right Panel)  
+   DETAIL SCREEN - two-panel layout
    ============================================================================ */
-#selected-workflow-detail {
-    width: 1fr;
-    padding: 0 1;
+#detail-body {
+    height: 1fr;
+    padding: 0 2;
 }
 
-WorkflowDetailOverview {
-    max-height: 11;
+#detail-left {
+    width: 1fr;
+    max-width: 50;
+    height: 1fr;
+}
+
+#detail-rules {
+    height: 2fr;
+}
+
+#detail-jobs {
+    height: 1fr;
+    overflow-y: auto;
+}
+
+#detail-tabs {
+    width: 2fr;
+    height: 1fr;
 }
 
 /* ============================================================================
@@ -153,13 +123,10 @@ WorkflowDetailOverview {
    ============================================================================ */
 #error-container {
     height: 1fr;
-    
-    
 }
 
 .error-text {
     color: $text-error;
-    
 }
 
 /* ============================================================================
@@ -208,34 +175,4 @@ ConfirmDeleteModal {
     content-align: center middle;
     text-align: center;
     color: $text-muted;
-}
-
-/* ============================================================================
-   LEGACY STYLES (May be unused after refactoring)
-   ============================================================================ */
-
-/* Legacy WorkflowDashboard - Check if still used */
-WorkflowDashboard {
-    layout: horizontal;
-    height: 1fr;
-}
-
-/* Legacy workflow overview component */
-WorkflowOverview {
-    max-height: 11;
-}
-
-/* Legacy workflow errors */
-#workflow-errors {
-    overflow-y: auto;
-    scrollbar-gutter: stable;
-}
-
-/* Legacy detail classes */
-.workflow-overview {
-    height: 1fr;
-}
-
-.selected-workflow-detail {
-    height: 3fr;
 }

--- a/src/snkmt/console/snkmt.tcss
+++ b/src/snkmt/console/snkmt.tcss
@@ -65,31 +65,68 @@ WorkflowTable {
 }
 
 /* ============================================================================
-   DETAIL SCREEN - two-panel layout
+   DETAIL SCREEN - Option A layout
    ============================================================================ */
 #detail-body {
     height: 1fr;
     padding: 0 2;
+    layout: vertical;
 }
 
-#detail-left {
+#detail-overview {
+    height: auto;
+    border: round $accent 20%;
+    border-title-color: $text-accent 50%;
+    border-title-align: center;
+    margin-bottom: 1;
+}
+
+#overview-header-layout {
+    height: auto;
+    layout: horizontal;
+    width: 100%;
+}
+
+.overview-card {
     width: 1fr;
-    max-width: 50;
-    height: 1fr;
+    height: auto;
+    padding: 0 2;
+    border-right: solid $accent 20%;
+}
+
+#card-command {
+    border-right: none;
+}
+
+.card-label {
+    color: $text-muted;
+    text-style: bold;
+}
+
+.card-value {
+    color: $text-primary;
+    margin-bottom: 1;
+}
+
+#detail-middle {
+    height: 1.2fr;
+    layout: horizontal;
+    margin-bottom: 1;
 }
 
 #detail-rules {
-    height: 2fr;
+    width: 5fr;
+    height: 100%;
 }
 
 #detail-jobs {
-    height: 1fr;
+    width: 3fr;
+    height: 100%;
     overflow-y: auto;
 }
 
-#detail-tabs {
-    width: 2fr;
-    height: 1fr;
+#detail-bottom-tabs {
+    height: 1.8fr;
 }
 
 /* ============================================================================

--- a/src/snkmt/console/views/detail.py
+++ b/src/snkmt/console/views/detail.py
@@ -1,0 +1,174 @@
+from uuid import UUID
+from typing import Optional
+
+from textual import on, work
+from textual.app import ComposeResult
+from textual.containers import Container, Horizontal, Vertical
+from textual.css.query import NoMatches
+from textual.screen import Screen
+from textual.widgets import Footer, Label, TabbedContent, TabPane
+
+from snkmt.console.widgets import (
+    JobTable,
+    ResourcesPanel,
+    RuleTable,
+    WorkflowDetailOverview,
+    WorkflowErrors,
+)
+from snkmt.core.repository import WorkflowRepository
+from snkmt.types.dto import WorkflowDTO
+
+
+class WorkflowDetailScreen(Screen):
+    """Full-screen detail view for a selected workflow. Esc returns to list."""
+
+    BINDINGS = [
+        ("escape", "app.pop_screen", "Back"),
+        ("tab", "focus_next", "Next"),
+        ("shift+tab", "focus_previous", "Previous"),
+    ]
+
+    def __init__(
+        self,
+        repo: WorkflowRepository,
+        workflow_id: str,
+        datasource: Optional[str] = None,
+    ) -> None:
+        super().__init__()
+        self.repo = repo
+        self.workflow_id = UUID(workflow_id)
+        self.datasource = datasource
+        self._workflow_data: Optional[WorkflowDTO] = None
+
+    def compose(self) -> ComposeResult:
+        with Horizontal(id="detail-body"):
+            # Left panel: rules + jobs
+            with Vertical(id="detail-left"):
+                rule_container = Container(classes="subsection", id="detail-rules")
+                rule_container.border_title = "Rules"
+                with rule_container:
+                    yield RuleTable(self.repo, id="detail-rule-table")
+
+                job_container = Container(classes="subsection", id="detail-jobs")
+                job_container.border_title = "Jobs"
+                with job_container:
+                    yield Label("Select a rule to view jobs.", id="jobs-placeholder")
+                    job_table = JobTable(self.repo, id="detail-job-table")
+                    job_table.display = False
+                    yield job_table
+
+            # Right panel: tabbed detail
+            with TabbedContent(id="detail-tabs"):
+                with TabPane("Overview", id="tab-overview"):
+                    overview = WorkflowDetailOverview(id="detail-overview")
+                    overview.border_title = ""
+                    yield overview
+
+                with TabPane("Logs", id="tab-logs"):
+                    yield Label("Select a job on the left to view its log files.", id="logs-placeholder")
+
+                with TabPane("Resources", id="tab-resources"):
+                    yield ResourcesPanel(id="detail-resources")
+
+                with TabPane("Errors", id="tab-errors"):
+                    yield WorkflowErrors(repo=self.repo, id="detail-errors")
+
+        yield Footer(id="detail-footer")
+
+    def on_mount(self) -> None:
+        self._load_workflow()
+
+    @work(exclusive=True)
+    async def _load_workflow(self) -> None:
+        workflow = await self.repo.get(self.workflow_id)
+        if workflow is None:
+            return
+        self._workflow_data = workflow
+
+        try:
+            overview = self.query_one(WorkflowDetailOverview)
+            overview.workflow_data = workflow
+        except NoMatches:
+            pass
+
+        try:
+            rule_table = self.query_one("#detail-rule-table", RuleTable)
+            rule_table.workflow_id = self.workflow_id
+        except NoMatches:
+            pass
+
+        try:
+            errors = self.query_one(WorkflowErrors)
+            errors.workflow_id = self.workflow_id
+        except NoMatches:
+            pass
+
+    @on(RuleTable.RowSelected, "#detail-rule-table")
+    async def handle_rule_selected(self, event: RuleTable.RowSelected) -> None:
+        rule_name = event.row_key.value
+        if rule_name is None:
+            return
+
+        rules = await self.repo.list_rules(workflow_id=self.workflow_id)
+        rule = next((r for r in rules if r.name == rule_name), None)
+        if rule is None:
+            return
+
+        try:
+            job_table = self.query_one("#detail-job-table", JobTable)
+            job_table.workflow_id = self.workflow_id
+            job_table.rule_id = rule.id
+            job_table.display = True
+
+            placeholder = self.query_one("#jobs-placeholder")
+            placeholder.display = False
+        except NoMatches:
+            pass
+
+    @on(JobTable.RowSelected, "#detail-job-table")
+    async def handle_job_selected(self, event: JobTable.RowSelected) -> None:
+        job_id_str = event.row_key.value
+        if job_id_str is None:
+            return
+
+        job = await self.repo.get_job(self.workflow_id, int(job_id_str))
+        if job is None:
+            return
+
+        try:
+            resources_panel = self.query_one(ResourcesPanel)
+            resources_panel.job_data = job
+        except NoMatches:
+            pass
+
+        await self._update_logs_tab(job)
+
+    async def _update_logs_tab(self, job) -> None:  # type: ignore[no-untyped-def]
+        from pathlib import Path
+        from textual.widgets import ListView, ListItem, Static
+
+        try:
+            logs_pane = self.query_one("#tab-logs")
+            await logs_pane.query("*").exclude("#logs-placeholder").remove()
+
+            log_files = job.log_files
+            if not log_files:
+                try:
+                    self.query_one("#logs-placeholder").display = True
+                except NoMatches:
+                    await logs_pane.mount(Label("No log files for this job.", id="logs-placeholder"))
+                return
+
+            try:
+                self.query_one("#logs-placeholder").display = False
+            except NoMatches:
+                pass
+
+            items = [
+                ListItem(Static(str(Path(lf.path).name)), name=str(lf.path))
+                for lf in log_files
+            ]
+            list_view = ListView(*items)
+            await logs_pane.mount(list_view)
+        except NoMatches:
+            pass

--- a/src/snkmt/console/views/detail.py
+++ b/src/snkmt/console/views/detail.py
@@ -11,6 +11,7 @@ from textual.widgets import Footer, Label, ListView, ListItem, Static, TabbedCon
 
 from snkmt.console.widgets import (
     JobTable,
+    LogFileModal,
     ResourcesPanel,
     RuleTable,
     WorkflowDetailOverview,
@@ -28,6 +29,7 @@ class WorkflowDetailScreen(Screen):
         ("tab", "focus_next", "Next"),
         ("shift+tab", "focus_previous", "Previous"),
         ("r", "force_refresh", "Refresh"),
+        ("m", "open_log_modal", "Expand log"),
     ]
 
     def __init__(
@@ -41,6 +43,7 @@ class WorkflowDetailScreen(Screen):
         self.workflow_id = UUID(workflow_id)
         self.datasource = datasource
         self._workflow_data: Optional[WorkflowDTO] = None
+        self._current_log_path: Optional[str] = None
 
     def action_force_refresh(self) -> None:
         try:
@@ -54,6 +57,11 @@ class WorkflowDetailScreen(Screen):
         except NoMatches:
             pass
         self._load_workflow()
+
+    def action_open_log_modal(self) -> None:
+        if self._current_log_path is None:
+            return
+        self.app.push_screen(LogFileModal(Path(self._current_log_path)))
 
     def compose(self) -> ComposeResult:
         with Horizontal(id="detail-body"):
@@ -162,6 +170,7 @@ class WorkflowDetailScreen(Screen):
         try:
             logs_pane = self.query_one("#tab-logs", TabPane)
             await logs_pane.query("*").remove()
+            self._current_log_path = None
 
             log_files = job.log_files
             if not log_files:
@@ -181,6 +190,7 @@ class WorkflowDetailScreen(Screen):
             pass
 
     async def _show_log_file(self, logs_pane: TabPane, path: str) -> None:
+        self._current_log_path = path
         try:
             logs_pane.query_one("#log-content").remove()
         except NoMatches:

--- a/src/snkmt/console/views/detail.py
+++ b/src/snkmt/console/views/detail.py
@@ -27,6 +27,7 @@ class WorkflowDetailScreen(Screen):
         ("escape", "app.pop_screen", "Back"),
         ("tab", "focus_next", "Next"),
         ("shift+tab", "focus_previous", "Previous"),
+        ("r", "force_refresh", "Refresh"),
     ]
 
     def __init__(
@@ -40,6 +41,19 @@ class WorkflowDetailScreen(Screen):
         self.workflow_id = UUID(workflow_id)
         self.datasource = datasource
         self._workflow_data: Optional[WorkflowDTO] = None
+
+    def action_force_refresh(self) -> None:
+        try:
+            self.query_one("#detail-rule-table", RuleTable)._refresh_table()
+        except NoMatches:
+            pass
+        try:
+            job_table = self.query_one("#detail-job-table", JobTable)
+            if job_table.display:
+                job_table._refresh_jobs()
+        except NoMatches:
+            pass
+        self._load_workflow()
 
     def compose(self) -> ComposeResult:
         with Horizontal(id="detail-body"):

--- a/src/snkmt/console/views/detail.py
+++ b/src/snkmt/console/views/detail.py
@@ -7,7 +7,7 @@ from textual.containers import Container, Horizontal, Vertical
 from textual.css.query import NoMatches
 from textual.screen import Screen
 from pathlib import Path
-from textual.widgets import Footer, Label, ListItem, ListView, Static, TabbedContent, TabPane
+from textual.widgets import Footer, Label, ListView, ListItem, Static, TabbedContent, TabPane, Log
 
 from snkmt.console.widgets import (
     JobTable,
@@ -80,7 +80,7 @@ class WorkflowDetailScreen(Screen):
                     yield overview
 
                 with TabPane("Logs", id="tab-logs"):
-                    yield Label("Select a job on the left to view its log files.", id="logs-placeholder")
+                    pass
 
                 with TabPane("Resources", id="tab-resources"):
                     yield ResourcesPanel(id="detail-resources")
@@ -161,26 +161,48 @@ class WorkflowDetailScreen(Screen):
     async def _update_logs_tab(self, job: JobDTO) -> None:
         try:
             logs_pane = self.query_one("#tab-logs")
-            await logs_pane.query("*").exclude("#logs-placeholder").remove()
+            await logs_pane.query("*").remove()
 
             log_files = job.log_files
             if not log_files:
-                try:
-                    self.query_one("#logs-placeholder").display = True
-                except NoMatches:
-                    await logs_pane.mount(Label("No log files for this job.", id="logs-placeholder"))
+                await logs_pane.mount(Label("No log files for this job.", id="logs-placeholder"))
                 return
 
-            try:
-                self.query_one("#logs-placeholder").display = False
-            except NoMatches:
-                pass
+            if len(log_files) > 1:
+                items = [
+                    ListItem(Static(str(Path(lf.path).name)), name=str(lf.path))
+                    for lf in log_files
+                ]
+                list_view = ListView(*items, id="logs-file-list")
+                await logs_pane.mount(list_view)
 
-            items = [
-                ListItem(Static(str(Path(lf.path).name)), name=str(lf.path))
-                for lf in log_files
-            ]
-            list_view = ListView(*items)
-            await logs_pane.mount(list_view)
+            await self._show_log_file(logs_pane, str(log_files[0].path))
+        except NoMatches:
+            pass
+
+    async def _show_log_file(self, logs_pane: TabPane, path: str) -> None:
+        try:
+            logs_pane.query_one("#log-content").remove()
+        except NoMatches:
+            pass
+
+        log_widget = Log(id="log-content", highlight=False)
+        await logs_pane.mount(log_widget)
+
+        try:
+            content = Path(path).read_text(errors="replace")
+            for line in content.splitlines():
+                log_widget.write_line(line)
+        except OSError:
+            log_widget.write_line(f"Could not read: {path}")
+
+    @on(ListView.Selected, "#logs-file-list")
+    async def handle_log_file_selected(self, event: ListView.Selected) -> None:
+        path = event.item.name
+        if path is None:
+            return
+        try:
+            logs_pane = self.query_one("#tab-logs")
+            await self._show_log_file(logs_pane, path)
         except NoMatches:
             pass

--- a/src/snkmt/console/views/detail.py
+++ b/src/snkmt/console/views/detail.py
@@ -160,7 +160,7 @@ class WorkflowDetailScreen(Screen):
 
     async def _update_logs_tab(self, job: JobDTO) -> None:
         try:
-            logs_pane = self.query_one("#tab-logs")
+            logs_pane = self.query_one("#tab-logs", TabPane)
             await logs_pane.query("*").remove()
 
             log_files = job.log_files
@@ -202,7 +202,7 @@ class WorkflowDetailScreen(Screen):
         if path is None:
             return
         try:
-            logs_pane = self.query_one("#tab-logs")
+            logs_pane = self.query_one("#tab-logs", TabPane)
             await self._show_log_file(logs_pane, path)
         except NoMatches:
             pass

--- a/src/snkmt/console/views/detail.py
+++ b/src/snkmt/console/views/detail.py
@@ -7,7 +7,16 @@ from textual.containers import Container, Horizontal, Vertical
 from textual.css.query import NoMatches
 from textual.screen import Screen
 from pathlib import Path
-from textual.widgets import Footer, Label, ListView, ListItem, Static, TabbedContent, TabPane, Log
+from textual.widgets import (
+    Footer,
+    Label,
+    ListView,
+    ListItem,
+    Static,
+    TabbedContent,
+    TabPane,
+    Log,
+)
 
 from snkmt.console.widgets import (
     JobTable,
@@ -174,7 +183,9 @@ class WorkflowDetailScreen(Screen):
 
             log_files = job.log_files
             if not log_files:
-                await logs_pane.mount(Label("No log files for this job.", id="logs-placeholder"))
+                await logs_pane.mount(
+                    Label("No log files for this job.", id="logs-placeholder")
+                )
                 return
 
             if len(log_files) > 1:
@@ -192,7 +203,7 @@ class WorkflowDetailScreen(Screen):
     async def _show_log_file(self, logs_pane: TabPane, path: str) -> None:
         self._current_log_path = path
         try:
-            logs_pane.query_one("#log-content").remove()
+            await logs_pane.query_one("#log-content").remove()
         except NoMatches:
             pass
 

--- a/src/snkmt/console/views/detail.py
+++ b/src/snkmt/console/views/detail.py
@@ -6,7 +6,8 @@ from textual.app import ComposeResult
 from textual.containers import Container, Horizontal, Vertical
 from textual.css.query import NoMatches
 from textual.screen import Screen
-from textual.widgets import Footer, Label, TabbedContent, TabPane
+from pathlib import Path
+from textual.widgets import Footer, Label, ListItem, ListView, Static, TabbedContent, TabPane
 
 from snkmt.console.widgets import (
     JobTable,
@@ -143,10 +144,7 @@ class WorkflowDetailScreen(Screen):
 
         await self._update_logs_tab(job)
 
-    async def _update_logs_tab(self, job) -> None:  # type: ignore[no-untyped-def]
-        from pathlib import Path
-        from textual.widgets import ListView, ListItem, Static
-
+    async def _update_logs_tab(self, job: WorkflowDTO) -> None:
         try:
             logs_pane = self.query_one("#tab-logs")
             await logs_pane.query("*").exclude("#logs-placeholder").remove()

--- a/src/snkmt/console/views/detail.py
+++ b/src/snkmt/console/views/detail.py
@@ -17,7 +17,7 @@ from snkmt.console.widgets import (
     WorkflowErrors,
 )
 from snkmt.core.repository import WorkflowRepository
-from snkmt.types.dto import WorkflowDTO
+from snkmt.types.dto import JobDTO, WorkflowDTO
 
 
 class WorkflowDetailScreen(Screen):
@@ -124,7 +124,7 @@ class WorkflowDetailScreen(Screen):
         if rule_name is None:
             return
 
-        rules = await self.repo.list_rules(workflow_id=self.workflow_id)
+        rules = await self.repo.list_rules(workflow_id=self.workflow_id, status=None)
         rule = next((r for r in rules if r.name == rule_name), None)
         if rule is None:
             return
@@ -158,7 +158,7 @@ class WorkflowDetailScreen(Screen):
 
         await self._update_logs_tab(job)
 
-    async def _update_logs_tab(self, job: WorkflowDTO) -> None:
+    async def _update_logs_tab(self, job: JobDTO) -> None:
         try:
             logs_pane = self.query_one("#tab-logs")
             await logs_pane.query("*").exclude("#logs-placeholder").remove()

--- a/src/snkmt/console/views/detail.py
+++ b/src/snkmt/console/views/detail.py
@@ -73,9 +73,12 @@ class WorkflowDetailScreen(Screen):
         self.app.push_screen(LogFileModal(Path(self._current_log_path)))
 
     def compose(self) -> ComposeResult:
-        with Horizontal(id="detail-body"):
-            # Left panel: rules + jobs
-            with Vertical(id="detail-left"):
+        with Vertical(id="detail-body"):
+            # Top row: Workflow summary header
+            yield WorkflowDetailOverview(id="detail-overview")
+
+            # Middle row: Rules and Jobs side-by-side
+            with Horizontal(id="detail-middle"):
                 rule_container = Container(classes="subsection", id="detail-rules")
                 rule_container.border_title = "Rules"
                 with rule_container:
@@ -89,13 +92,8 @@ class WorkflowDetailScreen(Screen):
                     job_table.display = False
                     yield job_table
 
-            # Right panel: tabbed detail
-            with TabbedContent(id="detail-tabs"):
-                with TabPane("Overview", id="tab-overview"):
-                    overview = WorkflowDetailOverview(id="detail-overview")
-                    overview.border_title = ""
-                    yield overview
-
+            # Bottom row: Tabs (Logs, Resources, and Errors)
+            with TabbedContent(id="detail-bottom-tabs"):
                 with TabPane("Logs", id="tab-logs"):
                     pass
 

--- a/src/snkmt/console/views/overview.py
+++ b/src/snkmt/console/views/overview.py
@@ -1,6 +1,5 @@
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal
-from textual.reactive import reactive
 from textual.widgets import Input, Label, Select
 from textual import on
 from textual.css.query import NoMatches
@@ -21,11 +20,17 @@ class WorkflowListView(Container):
             super().__init__()
 
     def __init__(self, repo: WorkflowRepository) -> None:
-        super().__init__()
+        super().__init__(classes="section")
         self.repo = repo
 
+    def force_refresh(self) -> None:
+        try:
+            self.query_one(WorkflowTable)._refresh_table()
+        except NoMatches:
+            pass
+
     def compose(self) -> ComposeResult:
-        with Container(id="workflows-filters") as filters:
+        with Container(classes="subsection", id="workflows-filters") as filters:
             filters.border_title = "Filters"
             with Horizontal(id="filter-layout"):
                 yield Input(placeholder="Filter by name...", id="name-filter", compact=True)

--- a/src/snkmt/console/views/overview.py
+++ b/src/snkmt/console/views/overview.py
@@ -33,7 +33,9 @@ class WorkflowListView(Container):
         with Container(classes="subsection", id="workflows-filters") as filters:
             filters.border_title = "Filters"
             with Horizontal(id="filter-layout"):
-                yield Input(placeholder="Filter by name...", id="name-filter", compact=True)
+                yield Input(
+                    placeholder="Filter by name...", id="name-filter", compact=True
+                )
                 yield Select(
                     [
                         ("Any time", DateFilter.ANY),
@@ -75,10 +77,14 @@ class WorkflowListView(Container):
     @on(Select.Changed, "#status-filter")
     async def filter_by_status(self, message: Select.Changed) -> None:
         if message.value is not None:
-            self.query_one(WorkflowTable).status_filter = cast(Union[str, Status], message.value)
+            self.query_one(WorkflowTable).status_filter = cast(
+                Union[str, Status], message.value
+            )
 
     @on(WorkflowTable.TableRefreshed)
-    async def handle_table_refreshed(self, message: WorkflowTable.TableRefreshed) -> None:
+    async def handle_table_refreshed(
+        self, message: WorkflowTable.TableRefreshed
+    ) -> None:
         try:
             label = self.query_one("#workflow-counts", Label)
             filtered_out = message.total_count - message.filtered_count

--- a/src/snkmt/console/views/overview.py
+++ b/src/snkmt/console/views/overview.py
@@ -2,213 +2,90 @@ from textual.app import ComposeResult
 from textual.containers import Container, Horizontal
 from textual.reactive import reactive
 from textual.widgets import Input, Label, Select
-from textual import on, work
+from textual import on
 from textual.css.query import NoMatches
+from textual.message import Message
 from typing import Union, cast
+
 from snkmt.core.repository import WorkflowRepository
-from snkmt.console.widgets import (
-    RuleTable,
-    WorkflowTable,
-    WorkflowDetailOverview,
-    WorkflowErrors,
-)
+from snkmt.console.widgets import WorkflowTable
 from snkmt.types.enums import Status, DateFilter
-from uuid import UUID
 
 
-class OverviewContainer(Horizontal):
-    BINDINGS = [
-        ("tab", "focus_next", "Next"),
-        ("shift+tab", "focus_previous", "Previous"),
-    ]
-    repo: reactive[WorkflowRepository | None] = reactive(None, recompose=True)
+class WorkflowListView(Container):
+    """Full-width workflow list with filters. Posts WorkflowSelected on row activation."""
+
+    class WorkflowSelected(Message):
+        def __init__(self, workflow_id: str) -> None:
+            self.workflow_id = workflow_id
+            super().__init__()
 
     def __init__(self, repo: WorkflowRepository) -> None:
         super().__init__()
-        self.set_reactive(OverviewContainer.repo, repo)
-        self.total_workflows = 0
-        self.filtered_workflows = 0
-        self.hidden_workflows = 0
-        self.selected_workflow = None
+        self.repo = repo
 
-    def force_refresh(self) -> None:
-        """Force refresh all visible tables in the current view."""
-        try:
-            workflow_table = self.query_one(WorkflowTable)
-            workflow_table._refresh_table()
-        except NoMatches:
-            pass
-        try:
-            rule_table = self.query_one(RuleTable)
-            if rule_table.display:
-                rule_table._refresh_table()
-        except NoMatches:
-            pass
+    def compose(self) -> ComposeResult:
+        with Container(id="workflows-filters") as filters:
+            filters.border_title = "Filters"
+            with Horizontal(id="filter-layout"):
+                yield Input(placeholder="Filter by name...", id="name-filter", compact=True)
+                yield Select(
+                    [
+                        ("Any time", DateFilter.ANY),
+                        ("Today", DateFilter.TODAY),
+                        ("Yesterday", DateFilter.YESTERDAY),
+                        ("Last 7 days", DateFilter.LAST_7_DAYS),
+                        ("Last 30 days", DateFilter.LAST_30_DAYS),
+                        ("Last 90 days", DateFilter.LAST_90_DAYS),
+                        ("This year", DateFilter.THIS_YEAR),
+                    ],
+                    value=DateFilter.ANY,
+                    id="date-filter",
+                    compact=True,
+                )
+                yield Select(
+                    [
+                        ("All statuses", "all"),
+                        ("Running", Status.RUNNING),
+                        ("Success", Status.SUCCESS),
+                        ("Error", Status.ERROR),
+                        ("Unknown", Status.UNKNOWN),
+                    ],
+                    value="all",
+                    id="status-filter",
+                    compact=True,
+                )
+            yield Label("", id="workflow-counts")
+        yield WorkflowTable(self.repo, id="workflow-table")
 
     @on(Input.Changed, "#name-filter")
     async def filter_by_name(self, message: Input.Changed) -> None:
-        """Handle name filter changes."""
-        workflow_table = self.query_one(WorkflowTable)
-        self.log.debug(f"name filter: {message.value}")
-        workflow_table.name_filter = message.value
+        self.query_one(WorkflowTable).name_filter = message.value
 
     @on(Select.Changed, "#date-filter")
     async def filter_by_date(self, message: Select.Changed) -> None:
-        """Handle date filter changes."""
-        workflow_table = self.query_one(WorkflowTable)
-        self.log.debug(f"date filter: {message.value} (type: {type(message.value)})")
         if message.value is not None:
-            workflow_table.date_filter = cast(DateFilter, message.value)
+            self.query_one(WorkflowTable).date_filter = cast(DateFilter, message.value)
 
     @on(Select.Changed, "#status-filter")
     async def filter_by_status(self, message: Select.Changed) -> None:
-        """Handle status filter changes."""
-        workflow_table = self.query_one(WorkflowTable)
-        self.log.debug(
-            f"status filter message.value: {message.value} (type: {type(message.value)})"
-        )
         if message.value is not None:
-            workflow_table.status_filter = cast(Union[str, Status], message.value)
+            self.query_one(WorkflowTable).status_filter = cast(Union[str, Status], message.value)
 
     @on(WorkflowTable.TableRefreshed)
-    async def handle_table_refreshed(
-        self, message: WorkflowTable.TableRefreshed
-    ) -> None:
-        """Handle table refresh with updated counts."""
-        self.total_workflows = message.total_count
-        self.filtered_workflows = message.filtered_count
-        self.hidden_workflows = message.hidden_count
-
+    async def handle_table_refreshed(self, message: WorkflowTable.TableRefreshed) -> None:
         try:
             label = self.query_one("#workflow-counts", Label)
-            visible_count = message.visible_count
-            filtered_out_count = message.total_count - message.filtered_count
+            filtered_out = message.total_count - message.filtered_count
             label.update(
-                f"Viewing {visible_count}/{message.total_count} workflows ({filtered_out_count} filtered, {message.hidden_count} hidden)"
+                f"Viewing {message.visible_count}/{message.total_count} "
+                f"({filtered_out} filtered, {message.hidden_count} hidden)"
             )
         except NoMatches:
             pass
 
-    @on(WorkflowTable.UpdatedWorkflows)
-    async def handle_updated_workflows(
-        self, message: WorkflowTable.UpdatedWorkflows
-    ) -> None:
-        """Handle workflow updates and set workflow data directly."""
-        if self.selected_workflow:
-            selected_workflow_data = next(
-                (
-                    w
-                    for w in message.workflows
-                    if str(w.id) == str(self.selected_workflow)
-                ),
-                None,
-            )
-            if selected_workflow_data:
-                detail_overview = self.query_one(WorkflowDetailOverview)
-                detail_overview.workflow_data = selected_workflow_data
-
     @on(WorkflowTable.RowSelected, "#workflow-table")
-    @work(exclusive=True)
     async def handle_workflow_selected(self, event: WorkflowTable.RowSelected) -> None:
-        """Handle row selection (clicking or pressing enter)."""
         workflow_id = event.row_key.value
-        self.log.debug(f"Selected workflow: {workflow_id}")
-        self.selected_workflow = workflow_id
-
-        if self.repo:
-            try:
-                workflow_data = await self.repo.get(UUID(workflow_id))
-                if workflow_data:
-                    detail_overview = self.query_one(WorkflowDetailOverview)
-                    detail_overview.workflow_data = workflow_data
-
-                    rule_table = self.query_one(RuleTable)
-                    rule_table.display = True
-                    rule_table.workflow_id = UUID(workflow_id)
-
-                    rules_placeholder = self.query_one("#rules-placeholder")
-                    rules_placeholder.display = False
-
-                    error_container = self.query_one(WorkflowErrors)
-                    error_container.workflow_id = UUID(workflow_id)
-            except NoMatches as e:
-                self.log.debug(f"Error fetching workflow {workflow_id}: {e}")
-
-    def compose(self) -> ComposeResult:
-        if self.repo:
-            # Left panel - Workflows table
-            with Container(
-                classes="section", id="workflows"
-            ) as workflow_table_container:
-                with Container(
-                    classes="subsection", id="workflows-filters"
-                ) as filters_container:
-                    filters_container.border_title = "Filters"
-                    with Horizontal(id="filter-layout"):
-                        yield Input(
-                            placeholder="Filter by name...",
-                            id="name-filter",
-                            compact=True,
-                        )
-                        yield Select(
-                            [
-                                ("Any time", DateFilter.ANY),
-                                ("Today", DateFilter.TODAY),
-                                ("Yesterday", DateFilter.YESTERDAY),
-                                ("Last 7 days", DateFilter.LAST_7_DAYS),
-                                ("Last 30 days", DateFilter.LAST_30_DAYS),
-                                ("Last 90 days", DateFilter.LAST_90_DAYS),
-                                ("This year", DateFilter.THIS_YEAR),
-                            ],
-                            value=DateFilter.ANY,
-                            id="date-filter",
-                            compact=True,
-                        )
-
-                        yield Select(
-                            [
-                                ("All statuses", "all"),
-                                ("Running", Status.RUNNING),
-                                ("Success", Status.SUCCESS),
-                                ("Error", Status.ERROR),
-                                ("Unknown", Status.UNKNOWN),
-                            ],
-                            value="all",
-                            id="status-filter",
-                            compact=True,
-                        )
-
-                    yield Label(
-                        "Viewing 0 workflows / 0 (0 filtered, 0 hidden)",
-                        id="workflow-counts",
-                    )
-                workflow_table_container.border_title = "Workflows"
-
-                yield WorkflowTable(self.repo, id="workflow-table")
-            # Right panel: info on selected workflow
-            with Container(
-                classes="section", id="selected-workflow-detail"
-            ) as workflow_detail_container:
-                workflow_detail_container.border_title = "Workflow Details"
-                workflow_overview = WorkflowDetailOverview(
-                    classes="subsection", id="workflow-overview"
-                )
-                workflow_overview.border_title = "Workflow Info"
-                yield workflow_overview
-
-                rules_container = Container(classes="subsection", id="workflow-rules")
-                rules_container.border_title = "Rules"
-                with rules_container:
-                    yield Label(
-                        "Please select a workflow to view rules.",
-                        id="rules-placeholder",
-                    )
-                    rule_table = RuleTable(self.repo)
-                    rule_table.display = False
-                    yield rule_table
-
-                errors_container = WorkflowErrors(
-                    repo=self.repo, classes="subsection", id="workflow-errors"
-                )
-                errors_container.border_title = "Errors"
-                yield errors_container
+        if workflow_id:
+            self.post_message(self.WorkflowSelected(str(workflow_id)))

--- a/src/snkmt/console/widgets.py
+++ b/src/snkmt/console/widgets.py
@@ -660,7 +660,9 @@ class JobTable(DataTable):
         jobs = await self.repo.list_rule_jobs(self.workflow_id, self.rule_id)
         for job in jobs:
             duration = f"{job.duration:.0f}s" if job.duration is not None else "running"
-            wildcards = ", ".join(f"{k}={v}" for k, v in (job.wildcards or {}).items()) or "—"
+            wildcards = (
+                ", ".join(f"{k}={v}" for k, v in (job.wildcards or {}).items()) or "—"
+            )
             self.add_row(
                 str(job.id),
                 StyledStatus(job.status),
@@ -681,7 +683,9 @@ class ResourcesPanel(Container):
     async def watch_job_data(self, job: JobDTO | None) -> None:
         await self.query("*").remove()
         if job is None:
-            await self.mount(Label("Select a job to view resources.", id="resources-placeholder"))
+            await self.mount(
+                Label("Select a job to view resources.", id="resources-placeholder")
+            )
             return
 
         table: DataTable[Any] = DataTable(id="resources-table")
@@ -698,7 +702,10 @@ class ResourcesPanel(Container):
         table.add_row(Text("duration", style="bold"), duration_str)
 
         if job.resources:
-            table.add_row(Text("── requested ──", style="dim"), Text("──────────────", style="dim"))
+            table.add_row(
+                Text("── requested ──", style="dim"),
+                Text("──────────────", style="dim"),
+            )
             for key, val in job.resources.items():
                 table.add_row(Text(key, style="bold"), str(val))
 
@@ -718,7 +725,9 @@ class ConfirmDeleteModal(ModalScreen[bool]):
         ("enter", "confirm", "Confirm Delete"),
     ]
 
-    def __init__(self, workflow_id: str, workflow_name: str, *args: Any, **kwargs: Any) -> None:
+    def __init__(
+        self, workflow_id: str, workflow_name: str, *args: Any, **kwargs: Any
+    ) -> None:
         self.workflow_id = workflow_id
         self.workflow_name = workflow_name
         super().__init__(*args, **kwargs)

--- a/src/snkmt/console/widgets.py
+++ b/src/snkmt/console/widgets.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Any, List, Optional, Union
 from uuid import UUID
 from textual import work
 from textual.reactive import reactive
@@ -63,7 +63,7 @@ class StyledStatus(Text):
 class RuleTable(DataTable):
     workflow_id: reactive[UUID | None] = reactive(None, layout=True)
 
-    def __init__(self, repo: WorkflowRepository, *args, **kwargs):
+    def __init__(self, repo: WorkflowRepository, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.repo = repo
         self.last_update: Optional[datetime] = None
@@ -198,7 +198,7 @@ class WorkflowTable(DataTable):
             self.workflows = workflows
             super().__init__()
 
-    def __init__(self, repo: WorkflowRepository, *args, **kwargs):
+    def __init__(self, repo: WorkflowRepository, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
         self.repo = repo
@@ -347,10 +347,10 @@ class WorkflowTable(DataTable):
 
                 self.app.push_screen(
                     ConfirmDeleteModal(workflow_id, workflow_name),
-                    callback=lambda confirmed: self._handle_delete_confirmed(
+                    callback=lambda confirmed: self._handle_delete_confirmed(  # type: ignore[arg-type]
                         confirmed, row_key, workflow_id
-                    ),  # type: ignore
-                )  # type: ignore
+                    ),
+                )
         except CellDoesNotExist as e:
             self.log.debug(f"Tried to delete workflow but failed: {e}")
 
@@ -416,7 +416,7 @@ class WorkflowTable(DataTable):
 class WorkflowDetailOverview(Container):
     workflow_data: reactive[WorkflowDTO | None] = reactive(None)
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._last_workflow_id: str | None = None
         self.border_title = "Workflow Info"
@@ -573,7 +573,7 @@ class WorkflowDetailOverview(Container):
 class WorkflowErrors(Container):
     workflow_id: reactive[UUID | None] = reactive(None, recompose=True)
 
-    def __init__(self, repo: WorkflowRepository, *args, **kwargs):
+    def __init__(self, repo: WorkflowRepository, *args: Any, **kwargs: Any) -> None:
         self.repo = repo
         super().__init__(*args, **kwargs)
 
@@ -645,7 +645,7 @@ class JobTable(DataTable):
     workflow_id: reactive[UUID | None] = reactive(None)
     rule_id: reactive[int | None] = reactive(None, layout=True)
 
-    def __init__(self, repo: WorkflowRepository, *args, **kwargs):
+    def __init__(self, repo: WorkflowRepository, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.repo = repo
         self._column_keys = self.add_columns("Job", "Status", "Duration", "Wildcards")
@@ -688,7 +688,7 @@ class ResourcesPanel(Container):
             await self.mount(Label("Select a job to view resources.", id="resources-placeholder"))
             return
 
-        table = DataTable(id="resources-table")
+        table: DataTable[Any] = DataTable(id="resources-table")
         table.add_column("Field", width=14)
         table.add_column("Value")
         table.cursor_type = "none"
@@ -720,7 +720,7 @@ class ConfirmDeleteModal(ModalScreen[bool]):
         ("enter", "confirm", "Confirm Delete"),
     ]
 
-    def __init__(self, workflow_id: str, workflow_name: str, *args, **kwargs):
+    def __init__(self, workflow_id: str, workflow_name: str, *args: Any, **kwargs: Any) -> None:
         self.workflow_id = workflow_id
         self.workflow_name = workflow_name
         super().__init__(*args, **kwargs)
@@ -756,7 +756,7 @@ class LogFileModal(ModalScreen):
 
     BINDINGS = [("escape", "app.pop_screen", "Pop screen")]
 
-    def __init__(self, log_file: Path, *args, **kwargs):
+    def __init__(self, log_file: Path, *args: Any, **kwargs: Any) -> None:
         self.log_file = log_file
         super().__init__(*args, **kwargs)
 

--- a/src/snkmt/console/widgets.py
+++ b/src/snkmt/console/widgets.py
@@ -26,12 +26,8 @@ from snkmt.core.repository import WorkflowRepository
 
 
 def render_progress_bar(progress: float, width: int = 8) -> Text:
-    """Return a Rich Text progress bar with colour."""
     progress = max(0.0, min(1.0, progress))
-    filled = round(progress * width)
-    bar = "█" * filled + "░" * (width - filled)
     pct = f"{progress:.0%}"
-    label = f"{bar} {pct:>4}"
 
     if progress < 0.2:
         color = "#fb4b4b"
@@ -43,7 +39,7 @@ def render_progress_bar(progress: float, width: int = 8) -> Text:
         color = "#feff5c"
     else:
         color = "#c0ff33"
-    return Text(label, style=color)
+    return Text(pct, style=color)
 
 
 class StyledStatus(Text):

--- a/src/snkmt/console/widgets.py
+++ b/src/snkmt/console/widgets.py
@@ -19,7 +19,7 @@ from textual.widgets.data_table import RowKey, CellDoesNotExist, DuplicateKey
 from datetime import datetime, timezone
 from rich.text import TextType, Text
 from textual.app import ComposeResult
-from textual.containers import Container
+from textual.containers import Container, Horizontal, Vertical
 from snkmt.types.dto import JobDTO, RuleDTO, WorkflowDTO
 from snkmt.types.enums import Status, DateFilter
 from snkmt.core.repository import WorkflowRepository
@@ -418,7 +418,28 @@ class WorkflowDetailOverview(Container):
         self.border_title = "Workflow Info"
 
     def compose(self) -> ComposeResult:
-        yield Label("Please select a workflow to view details.", id="placeholder-label")
+        with Horizontal(id="overview-header-layout"):
+            with Vertical(classes="overview-card", id="card-info"):
+                yield Label("[bold]Workflow ID[/bold]", classes="card-label")
+                yield Label("...", id="overview-id", classes="card-value")
+                yield Label("[bold]Snakefile[/bold]", classes="card-label")
+                yield Label("...", id="overview-snakefile", classes="card-value")
+
+            with Vertical(classes="overview-card", id="card-status"):
+                yield Label("[bold]Status[/bold]", classes="card-label")
+                yield Label("...", id="overview-status", classes="card-value")
+                yield Label("[bold]Progress[/bold]", classes="card-label")
+                yield Label("...", id="overview-progress", classes="card-value")
+
+            with Vertical(classes="overview-card", id="card-jobs"):
+                yield Label("[bold]Jobs Finished[/bold]", classes="card-label")
+                yield Label("...", id="overview-jobs-finished", classes="card-value")
+                yield Label("[bold]Total Jobs[/bold]", classes="card-label")
+                yield Label("...", id="overview-jobs-total", classes="card-value")
+
+            with Vertical(classes="overview-card", id="card-command"):
+                yield Label("[bold]Command Line[/bold]", classes="card-label")
+                yield Label("...", id="overview-command", classes="card-value")
 
     async def watch_workflow_data(
         self, old_data: WorkflowDTO | None, new_data: WorkflowDTO | None
@@ -426,144 +447,28 @@ class WorkflowDetailOverview(Container):
         if new_data is None:
             return
 
-        if old_data is None or str(old_data.id) != str(new_data.id):
-            self._last_workflow_id = str(new_data.id)
-            await self._rebuild_table(new_data)
-        else:
-            self._update_table_cells(old_data, new_data)
-
-    async def _rebuild_table(self, workflow: WorkflowDTO) -> None:
-        await self.query("*").exclude("#workflow-detail-table").remove()
-
         try:
-            self.query_one("#placeholder-label").remove()
+            self.query_one("#overview-id", Label).update(str(new_data.id))
+            self.query_one("#overview-snakefile", Label).update(
+                Path(new_data.snakefile).name if new_data.snakefile else "N/A"
+            )
+            self.query_one("#overview-status", Label).update(
+                StyledStatus(new_data.status)
+            )
+            self.query_one("#overview-progress", Label).update(
+                render_progress_bar(new_data.progress)
+            )
+            self.query_one("#overview-jobs-finished", Label).update(
+                str(new_data.jobs_finished)
+            )
+            self.query_one("#overview-jobs-total", Label).update(
+                str(new_data.total_job_count)
+            )
+            self.query_one("#overview-command", Label).update(
+                new_data.command_line or "N/A"
+            )
         except NoMatches:
             pass
-
-        try:
-            old_table = self.query_one("#workflow-detail-table", DataTable)
-            old_table.clear()
-            table = old_table
-        except NoMatches:
-            table = DataTable(id="workflow-detail-table")
-            table.add_column("Field", width=15)
-            table.add_column("Value")
-            table.cursor_type = "none"
-            table.show_cursor = False
-            table.show_header = False
-            await self.mount(table)
-
-        table.add_row(
-            Text("ID", justify="left", style="bold"),
-            Text(str(workflow.id), justify="left"),
-        )
-        table.add_row(
-            Text("Snakefile", justify="left", style="bold"),
-            Text(
-                workflow.snakefile or "N/A",
-                justify="left",
-                style="dim" if not workflow.snakefile else "",
-            ),
-        )
-        table.add_row(
-            Text("Started At", justify="left", style="bold"),
-            Text(
-                workflow.started_at.strftime("%Y-%m-%d %H:%M:%S")
-                if workflow.started_at
-                else "N/A",
-                justify="left",
-                style="dim" if not workflow.started_at else "",
-            ),
-        )
-        table.add_row(
-            Text("Updated At", justify="left", style="bold"),
-            Text(
-                workflow.updated_at.strftime("%Y-%m-%d %H:%M:%S")
-                if workflow.updated_at
-                else "N/A",
-                justify="left",
-                style="dim" if not workflow.updated_at else "",
-            ),
-        )
-        table.add_row(
-            Text("End Time", justify="left", style="bold"),
-            Text(
-                workflow.end_time.strftime("%Y-%m-%d %H:%M:%S")
-                if workflow.end_time
-                else "N/A",
-                justify="left",
-                style="dim" if not workflow.end_time else "",
-            ),
-        )
-        table.add_row(
-            Text("Status", justify="left", style="bold"),
-            StyledStatus(workflow.status),
-        )
-        table.add_row(
-            Text("Progress", justify="left", style="bold"),
-            render_progress_bar(workflow.progress),
-        )
-        table.add_row(
-            Text("Total Jobs", justify="left", style="bold"),
-            Text(str(workflow.total_job_count), justify="left"),
-        )
-        table.add_row(
-            Text("Jobs Finished", justify="left", style="bold"),
-            Text(str(workflow.jobs_finished), justify="left"),
-        )
-        if workflow.command_line:
-            table.add_row(
-                Text("Command", justify="left", style="bold"),
-                Text(workflow.command_line, justify="left"),
-            )
-
-    def _update_table_cells(self, old_data: WorkflowDTO, new_data: WorkflowDTO) -> None:
-        """Update individual table cells when workflow data changes."""
-        try:
-            table = self.query_one(DataTable)
-            rows = list(table.rows.keys())
-            columns = list(table.columns.values())
-            value_column_key = columns[1].key
-
-            if old_data.updated_at != new_data.updated_at and len(rows) > 3:
-                table.update_cell(
-                    rows[3],
-                    value_column_key,
-                    Text(
-                        new_data.updated_at.strftime("%Y-%m-%d %H:%M:%S")
-                        if new_data.updated_at
-                        else "N/A",
-                        justify="left",
-                        style="dim" if not new_data.updated_at else "",
-                    ),
-                )
-
-            if old_data.status != new_data.status and len(rows) > 5:
-                table.update_cell(
-                    rows[5], value_column_key, StyledStatus(new_data.status)
-                )
-
-            if old_data.progress != new_data.progress and len(rows) > 6:
-                table.update_cell(
-                    rows[6], value_column_key, render_progress_bar(new_data.progress)
-                )
-
-            if old_data.total_job_count != new_data.total_job_count and len(rows) > 7:
-                table.update_cell(
-                    rows[7],
-                    value_column_key,
-                    Text(str(new_data.total_job_count), justify="left"),
-                )
-
-            if old_data.jobs_finished != new_data.jobs_finished and len(rows) > 8:
-                table.update_cell(
-                    rows[8],
-                    value_column_key,
-                    Text(str(new_data.jobs_finished), justify="left"),
-                )
-
-        except NoMatches as e:
-            self.log.debug(f"Error updating cells: {e}")
 
 
 class WorkflowErrors(Container):

--- a/src/snkmt/console/widgets.py
+++ b/src/snkmt/console/widgets.py
@@ -671,7 +671,7 @@ class JobTable(DataTable):
 
 
 class ResourcesPanel(Container):
-    """Displays job resources dict, threads, duration, and shellcmd."""
+    """Displays job threads, duration, requested resources, shellcmd, and wildcards."""
 
     job_data: reactive[JobDTO | None] = reactive(None)
 
@@ -697,8 +697,10 @@ class ResourcesPanel(Container):
         duration_str = f"{job.duration:.1f}s" if job.duration is not None else "running"
         table.add_row(Text("duration", style="bold"), duration_str)
 
-        for key, val in (job.resources or {}).items():
-            table.add_row(Text(key, style="bold"), str(val))
+        if job.resources:
+            table.add_row(Text("── requested ──", style="dim"), Text("──────────────", style="dim"))
+            for key, val in job.resources.items():
+                table.add_row(Text(key, style="bold"), str(val))
 
         if job.shellcmd:
             table.add_row(Text("shellcmd", style="bold"), job.shellcmd)

--- a/src/snkmt/console/widgets.py
+++ b/src/snkmt/console/widgets.py
@@ -614,8 +614,17 @@ class ResourcesPanel(Container):
             for key, val in job.resources.items():
                 table.add_row(Text(key, style="bold"), str(val))
 
+        if job.reason:
+            clean_reason = " ".join(
+                line.strip() for line in job.reason.splitlines() if line.strip()
+            )
+            table.add_row(Text("reason", style="bold"), clean_reason)
+
         if job.shellcmd:
-            table.add_row(Text("shellcmd", style="bold"), job.shellcmd)
+            clean_cmd = " ".join(
+                line.strip() for line in job.shellcmd.splitlines() if line.strip()
+            )
+            table.add_row(Text("shellcmd", style="bold"), clean_cmd)
 
         if job.wildcards:
             for k, v in job.wildcards.items():

--- a/src/snkmt/console/widgets.py
+++ b/src/snkmt/console/widgets.py
@@ -25,21 +25,25 @@ from snkmt.types.enums import Status, DateFilter
 from snkmt.core.repository import WorkflowRepository
 
 
-class StyledProgress(Text):
-    def __init__(self, progress: float) -> None:
-        progstr = format(progress, ".2%")
+def render_progress_bar(progress: float, width: int = 8) -> Text:
+    """Return a Rich Text progress bar with colour."""
+    progress = max(0.0, min(1.0, progress))
+    filled = round(progress * width)
+    bar = "█" * filled + "░" * (width - filled)
+    pct = f"{progress:.0%}"
+    label = f"{bar} {pct:>4}"
 
-        if progress < 0.2:
-            color = "#fb4b4b"
-        elif progress < 0.4:
-            color = "#ffa879"
-        elif progress < 0.6:
-            color = "#ffc163"
-        elif progress < 0.8:
-            color = "#feff5c"
-        else:
-            color = "#c0ff33"
-        super().__init__(progstr, style=color)
+    if progress < 0.2:
+        color = "#fb4b4b"
+    elif progress < 0.4:
+        color = "#ffa879"
+    elif progress < 0.6:
+        color = "#ffc163"
+    elif progress < 0.8:
+        color = "#feff5c"
+    else:
+        color = "#c0ff33"
+    return Text(label, style=color)
 
 
 class StyledStatus(Text):
@@ -133,7 +137,7 @@ class RuleTable(DataTable):
 
         return [
             rule.name,
-            StyledProgress(progress),
+            render_progress_bar(progress),
             str(rule.total_job_count),
             str(rule.jobs_finished),
             str(rule.job_counts.running),
@@ -287,7 +291,7 @@ class WorkflowTable(DataTable):
             if workflow.started_at
             else "N/A"
         )
-        progress = StyledProgress(workflow.progress)
+        progress = render_progress_bar(workflow.progress)
         return [workflow_id[-6:], status, snakefile, started_at, progress]
 
     def _update_row(self, key: str, row_data: List[TextType]) -> None:
@@ -501,7 +505,7 @@ class WorkflowDetailOverview(Container):
         )
         table.add_row(
             Text("Progress", justify="left", style="bold"),
-            StyledProgress(workflow.progress),
+            render_progress_bar(workflow.progress),
         )
         table.add_row(
             Text("Total Jobs", justify="left", style="bold"),
@@ -540,7 +544,7 @@ class WorkflowDetailOverview(Container):
 
             if old_data.progress != new_data.progress and len(rows) > 6:
                 table.update_cell(
-                    rows[6], value_column_key, StyledProgress(new_data.progress)
+                    rows[6], value_column_key, render_progress_bar(new_data.progress)
                 )
 
             if old_data.total_job_count != new_data.total_job_count and len(rows) > 7:

--- a/src/snkmt/console/widgets.py
+++ b/src/snkmt/console/widgets.py
@@ -634,6 +634,79 @@ class WorkflowErrors(Container):
             await self.mount(collapsible)
 
 
+class JobTable(DataTable):
+    """Shows jobs for a selected rule. Set workflow_id + rule_id to load."""
+
+    workflow_id: reactive[UUID | None] = reactive(None)
+    rule_id: reactive[int | None] = reactive(None, layout=True)
+
+    def __init__(self, repo: WorkflowRepository, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.repo = repo
+        self._column_keys = self.add_columns("Job", "Status", "Duration", "Wildcards")
+        self.cursor_type = "row"
+        self.cursor_foreground_priority = "renderable"
+
+    def watch_rule_id(self) -> None:
+        if self.rule_id is not None and self.workflow_id is not None:
+            self._refresh_jobs()
+
+    @work(exclusive=True)
+    async def _refresh_jobs(self) -> None:
+        if self.workflow_id is None or self.rule_id is None:
+            return
+        self.clear()
+        jobs = await self.repo.list_rule_jobs(self.workflow_id, self.rule_id)
+        for job in jobs:
+            duration = f"{job.duration:.0f}s" if job.duration is not None else "running"
+            wildcards = ", ".join(f"{k}={v}" for k, v in (job.wildcards or {}).items()) or "—"
+            self.add_row(
+                str(job.id),
+                StyledStatus(job.status),
+                duration,
+                wildcards,
+                key=str(job.id),
+            )
+
+
+class ResourcesPanel(Container):
+    """Displays job resources dict, threads, duration, and shellcmd."""
+
+    job_data: reactive[JobDTO | None] = reactive(None)
+
+    def compose(self) -> ComposeResult:
+        yield Label("Select a job to view resources.", id="resources-placeholder")
+
+    async def watch_job_data(self, job: JobDTO | None) -> None:
+        await self.query("*").remove()
+        if job is None:
+            await self.mount(Label("Select a job to view resources.", id="resources-placeholder"))
+            return
+
+        table = DataTable(id="resources-table")
+        table.add_column("Field", width=14)
+        table.add_column("Value")
+        table.cursor_type = "none"
+        table.show_cursor = False
+        table.show_header = False
+        await self.mount(table)
+
+        table.add_row(Text("threads", style="bold"), str(job.threads))
+
+        duration_str = f"{job.duration:.1f}s" if job.duration is not None else "running"
+        table.add_row(Text("duration", style="bold"), duration_str)
+
+        for key, val in (job.resources or {}).items():
+            table.add_row(Text(key, style="bold"), str(val))
+
+        if job.shellcmd:
+            table.add_row(Text("shellcmd", style="bold"), job.shellcmd)
+
+        if job.wildcards:
+            for k, v in job.wildcards.items():
+                table.add_row(Text(f"wildcard:{k}", style="bold"), str(v))
+
+
 class ConfirmDeleteModal(ModalScreen[bool]):
     """Modal to confirm workflow deletion."""
 

--- a/src/snkmt/console/widgets.py
+++ b/src/snkmt/console/widgets.py
@@ -515,6 +515,11 @@ class WorkflowDetailOverview(Container):
             Text("Jobs Finished", justify="left", style="bold"),
             Text(str(workflow.jobs_finished), justify="left"),
         )
+        if workflow.command_line:
+            table.add_row(
+                Text("Command", justify="left", style="bold"),
+                Text(workflow.command_line, justify="left"),
+            )
 
     def _update_table_cells(self, old_data: WorkflowDTO, new_data: WorkflowDTO) -> None:
         """Update individual table cells when workflow data changes."""

--- a/src/snkmt/core/repository/sql.py
+++ b/src/snkmt/core/repository/sql.py
@@ -348,8 +348,10 @@ class SQLAlchemyWorkflowRepository(WorkflowRepository):
 
     async def get_job(self, workflow_id: UUID, job_id: int) -> Optional[JobDTO]:
         async with self.async_session() as session:
-            stmt = select(Job).where(
-                and_(Job.id == job_id, Job.workflow_id == workflow_id)
+            stmt = (
+                select(Job)
+                .options(selectinload(Job.files))
+                .where(and_(Job.id == job_id, Job.workflow_id == workflow_id))
             )
             result = await session.execute(stmt)
             job = result.scalar_one_or_none()

--- a/src/snkmt/core/repository/sql.py
+++ b/src/snkmt/core/repository/sql.py
@@ -55,6 +55,7 @@ class SQLAlchemyWorkflowRepository(WorkflowRepository):
                 started_at=workflow.started_at,
                 updated_at=workflow.updated_at,
                 dryrun=workflow.dryrun,
+                command_line=workflow.command_line,
             )
             session.add(new_workflow)
             await session.commit()
@@ -417,6 +418,7 @@ class SQLAlchemyWorkflowRepository(WorkflowRepository):
             snakefile=workflow.snakefile,
             end_time=workflow.end_time,
             dryrun=workflow.dryrun,
+            command_line=workflow.command_line,
             rule_ids=[r.id for r in workflow.rules]
             if hasattr(workflow, "rules") and workflow.rules
             else [],

--- a/src/snkmt/core/repository/sql.py
+++ b/src/snkmt/core/repository/sql.py
@@ -265,6 +265,7 @@ class SQLAlchemyWorkflowRepository(WorkflowRepository):
         async with self.async_session() as session:
             stmt = (
                 select(Job)
+                .options(selectinload(Job.files))
                 .join(Rule)
                 .where(and_(Rule.workflow_id == workflow_id, Job.rule_id == rule_id))
             )

--- a/src/snkmt/core/repository/sql.py
+++ b/src/snkmt/core/repository/sql.py
@@ -343,7 +343,7 @@ class SQLAlchemyWorkflowRepository(WorkflowRepository):
             )
             session.add(new_job)
             await session.commit()
-            await session.refresh(new_job)
+            await session.refresh(new_job, ["files"])
             return self._job_to_dto(new_job)
 
     async def get_job(self, workflow_id: UUID, job_id: int) -> Optional[JobDTO]:
@@ -361,11 +361,15 @@ class SQLAlchemyWorkflowRepository(WorkflowRepository):
         self, workflow_id: UUID, rule_id: int, job_id: int, update: UpdateJobDTO
     ) -> Optional[JobDTO]:
         async with self.async_session() as session:
-            stmt = select(Job).where(
-                and_(
-                    Job.id == job_id,
-                    Job.workflow_id == workflow_id,
-                    Job.rule_id == rule_id,
+            stmt = (
+                select(Job)
+                .options(selectinload(Job.files))
+                .where(
+                    and_(
+                        Job.id == job_id,
+                        Job.workflow_id == workflow_id,
+                        Job.rule_id == rule_id,
+                    )
                 )
             )
             result = await session.execute(stmt)

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1,10 +1,9 @@
-import pytest
+import inspect
 from snkmt.console.views.overview import WorkflowListView
 
 
 def test_workflow_list_view_posts_selected_message():
     """WorkflowListView must declare a WorkflowSelected message with a workflow_id str."""
     msg_cls = WorkflowListView.WorkflowSelected
-    import inspect
     sig = inspect.signature(msg_cls.__init__)
     assert "workflow_id" in sig.parameters

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -28,3 +28,8 @@ def test_progress_bar_half():
 def test_progress_bar_clamps():
     result = render_progress_bar(1.5, width=10)
     assert result.plain == "██████████ 100%"
+
+
+def test_workflow_detail_screen_importable():
+    from snkmt.console.views.detail import WorkflowDetailScreen
+    assert WorkflowDetailScreen is not None

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1,13 +1,4 @@
-import inspect
-from snkmt.console.views.overview import WorkflowListView
 from snkmt.console.widgets import render_progress_bar
-
-
-def test_workflow_list_view_posts_selected_message():
-    """WorkflowListView must declare a WorkflowSelected message with a workflow_id str."""
-    msg_cls = WorkflowListView.WorkflowSelected
-    sig = inspect.signature(msg_cls.__init__)
-    assert "workflow_id" in sig.parameters
 
 
 def test_progress_bar_empty():
@@ -28,8 +19,3 @@ def test_progress_bar_half():
 def test_progress_bar_clamps():
     result = render_progress_bar(1.5)
     assert result.plain == "100%"
-
-
-def test_workflow_detail_screen_importable():
-    from snkmt.console.views.detail import WorkflowDetailScreen
-    assert WorkflowDetailScreen is not None

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -11,23 +11,23 @@ def test_workflow_list_view_posts_selected_message():
 
 
 def test_progress_bar_empty():
-    result = render_progress_bar(0.0, width=10)
-    assert result.plain == "░░░░░░░░░░   0%"
+    result = render_progress_bar(0.0)
+    assert result.plain == "0%"
 
 
 def test_progress_bar_full():
-    result = render_progress_bar(1.0, width=10)
-    assert result.plain == "██████████ 100%"
+    result = render_progress_bar(1.0)
+    assert result.plain == "100%"
 
 
 def test_progress_bar_half():
-    result = render_progress_bar(0.5, width=10)
-    assert result.plain == "█████░░░░░  50%"
+    result = render_progress_bar(0.5)
+    assert result.plain == "50%"
 
 
 def test_progress_bar_clamps():
-    result = render_progress_bar(1.5, width=10)
-    assert result.plain == "██████████ 100%"
+    result = render_progress_bar(1.5)
+    assert result.plain == "100%"
 
 
 def test_workflow_detail_screen_importable():

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1,0 +1,10 @@
+import pytest
+from snkmt.console.views.overview import WorkflowListView
+
+
+def test_workflow_list_view_posts_selected_message():
+    """WorkflowListView must declare a WorkflowSelected message with a workflow_id str."""
+    msg_cls = WorkflowListView.WorkflowSelected
+    import inspect
+    sig = inspect.signature(msg_cls.__init__)
+    assert "workflow_id" in sig.parameters

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1,5 +1,6 @@
 import inspect
 from snkmt.console.views.overview import WorkflowListView
+from snkmt.console.widgets import render_progress_bar
 
 
 def test_workflow_list_view_posts_selected_message():
@@ -7,9 +8,6 @@ def test_workflow_list_view_posts_selected_message():
     msg_cls = WorkflowListView.WorkflowSelected
     sig = inspect.signature(msg_cls.__init__)
     assert "workflow_id" in sig.parameters
-
-
-from snkmt.console.widgets import render_progress_bar
 
 
 def test_progress_bar_empty():

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -7,3 +7,26 @@ def test_workflow_list_view_posts_selected_message():
     msg_cls = WorkflowListView.WorkflowSelected
     sig = inspect.signature(msg_cls.__init__)
     assert "workflow_id" in sig.parameters
+
+
+from snkmt.console.widgets import render_progress_bar
+
+
+def test_progress_bar_empty():
+    result = render_progress_bar(0.0, width=10)
+    assert result.plain == "░░░░░░░░░░   0%"
+
+
+def test_progress_bar_full():
+    result = render_progress_bar(1.0, width=10)
+    assert result.plain == "██████████ 100%"
+
+
+def test_progress_bar_half():
+    result = render_progress_bar(0.5, width=10)
+    assert result.plain == "█████░░░░░  50%"
+
+
+def test_progress_bar_clamps():
+    result = render_progress_bar(1.5, width=10)
+    assert result.plain == "██████████ 100%"


### PR DESCRIPTION
**Layout:**

Replaced the single-screen layout (large workflow list + three cramped right panels) with a two-screen approach: a full-width workflow list as the default view, pushing a detail screen on selection. Esc returns to the list.

The detail screen has a left panel (rules drill-down → jobs) and a right tabbed panel (Overview / Logs / Resources / Errors).

**New features:**

* Log viewer in the Logs tab shows file content directly when a job is selected; a file selector appears only when a job has multiple log files
* Resources panel shows threads, duration, resource usage, shell command, and wildcards for the selected job
* Progress display shows percentage only (colour-coded by completion level)

**Bug fixes:**

* `list_rule_jobs` and `get_job` now eagerly load `job.files` via `selectinload` to prevent `MissingGreenlet` errors when accessing file relationships outside the async session context