### PR TITLE
fix: don't let in-process Alembic disable host application loggers

### DIFF
--- a/src/snkmt/core/db/alembic/env.py
+++ b/src/snkmt/core/db/alembic/env.py
@@ -11,8 +11,18 @@ from alembic import context
 config = context.config
 
 
+# Interpret the config file for Python logging.
+#
+# NOTE: ``disable_existing_loggers`` must stay False. Some snkmt code paths
+# (e.g. ``stamp_legacy_database``) invoke Alembic *in-process* rather than in a
+# subprocess, so this env.py runs inside the host application -- for example a
+# Snakemake run using the snkmt logger plugin. With the fileConfig default of
+# ``disable_existing_loggers=True``, Alembic would disable every logger not
+# named in alembic.ini -- including the host's loggers -- silently dropping
+# their records for the rest of the process. Keeping it False configures
+# Alembic's own loggers without tearing down anyone else's.
 if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+    fileConfig(config.config_file_name, disable_existing_loggers=False)
 
 # add your model's MetaData object here
 # for 'autogenerate' support

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -183,3 +183,45 @@ def test_legacy_database(temp_db_path, caplog):
         )
 
         assert f"Legacy database stamped with revision: {desired_rev}" in caplog.text
+
+
+def test_in_process_migration_does_not_disable_host_loggers(temp_db_path):
+    """Opening a legacy database stamps/migrates it via Alembic in-process.
+
+    Alembic's env.py runs ``logging.config.fileConfig`` whose default
+    ``disable_existing_loggers=True`` would disable every logger not named in
+    alembic.ini -- including loggers owned by the host application. When snkmt
+    is used as a Snakemake logger plugin this silently disabled Snakemake's
+    "snakemake.logging" logger, so the WORKFLOW_STARTED event was dropped and
+    every subsequent rule insert failed with
+    ``NOT NULL constraint failed: rules.workflow_id``.
+
+    Regression test: a pre-existing host logger must survive opening the DB.
+    """
+
+    import logging
+    import shutil
+
+    # A logger that mimics a host application's logger (e.g. Snakemake's),
+    # created *before* snkmt touches the database.
+    host_logger = logging.getLogger("snakemake.logging")
+    host_logger.addHandler(logging.NullHandler())
+    host_logger.setLevel(logging.INFO)
+    host_logger.disabled = False
+
+    legacy_db = Path("tests/fixtures/legacy.db")
+    shutil.copy(legacy_db, Path(temp_db_path))
+
+    # Opening a legacy DB triggers in-process stamping + migration.
+    db = Database(
+        db_path=str(temp_db_path),
+        create_db=False,
+        auto_migrate=True,
+        ignore_version=False,
+    )
+    db.close()
+
+    assert host_logger.disabled is False, (
+        "In-process Alembic migration disabled a host logger; "
+        "alembic env.py must use fileConfig(disable_existing_loggers=False)."
+    )


### PR DESCRIPTION
## Problem

Running Snakemake with the snkmt logger plugin against a database that needs stamping/migration crashes every job-logging insert with:

```
sqlite3.IntegrityError: NOT NULL constraint failed: rules.workflow_id
```

## Root cause

When `Database.__init__` opens a database that needs work, snkmt can invoke Alembic **in-process** — specifically `stamp_legacy_database()` (the actual `migrate()` already uses a subprocess). Alembic's `env.py` runs `logging.config.fileConfig(config.config_file_name)`, and `fileConfig` defaults to `disable_existing_loggers=True`, which **disables every logger not declared in `alembic.ini`**.

Snakemake logs through a named logger (`logging.getLogger("snakemake.logging")`). When snkmt is loaded as a Snakemake logger plugin, the in-process stamp disables that logger mid-run. The `WORKFLOW_STARTED` event is then silently dropped, so the handler never records a `Workflow` and `context["current_workflow_id"]` stays `None`. Every subsequent `JOB_INFO` event tries to `INSERT` a `Rule` with a `NULL` `workflow_id` and hits the `NOT NULL` constraint.

This matches the existing `# alembic messes with logging config` note in the logger plugin's `log_handler.close()`.

### Reproduced

A focused check shows `stamp_legacy_database()` flipping the host logger's `disabled` flag:

```
BEFORE: snake.disabled = False
AFTER:  snake.disabled = True
```

With the fix it stays `False`.

## Fix

Pass `disable_existing_loggers=False` in `env.py` so Alembic configures its own loggers without tearing down the host application's. This is safe for the subprocess migration path too (no host loggers to preserve there) and protects any future in-process Alembic use.

## Test

Adds `test_in_process_migration_does_not_disable_host_loggers`, which opens the existing `tests/fixtures/legacy.db` and asserts a pre-existing host logger is not disabled. It fails without the fix and passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)